### PR TITLE
MMC0 boot problem fixed

### DIFF
--- a/board/ti/am335x/mux.c
+++ b/board/ti/am335x/mux.c
@@ -65,7 +65,7 @@ static struct module_pin_mux mmc0_pin_mux[] = {
 	{OFFSET(mmc0_clk), (MODE(0) | RXACTIVE | PULLUP_EN)},	/* MMC0_CLK */
 	{OFFSET(mmc0_cmd), (MODE(0) | RXACTIVE | PULLUP_EN)},	/* MMC0_CMD */
 	{OFFSET(mcasp0_aclkr), (MODE(4) | RXACTIVE)},		/* MMC0_WP */
-	{OFFSET(spi0_cs1), (MODE(5) | RXACTIVE | PULLUP_EN)},	/* MMC0_CD */
+	{OFFSET(spi0_cs1), (MODE(5) | RXACTIVE )},		/* MMC0_CD */
 	{-1},
 };
 


### PR DESCRIPTION
Fixed MMC0 boot problem. There is an external pullup on the board, so internal one is not needed.
